### PR TITLE
Bugfixes

### DIFF
--- a/contentScripts/imgurContent.js
+++ b/contentScripts/imgurContent.js
@@ -177,6 +177,12 @@ function imgurContentMain() {
 					checkCount++;
 			}, 500);
 		});
+                            
+        // Since our mutationObserver tends to load too late to catch their inclusion, check to see if the comments have already been loaded.
+        // Note: This reduces but does not guarantee the elimination of the edge case where the comments load before the mutation observer.
+        // It's still possible for the comments to load after this line but before the mutation observer kicks in.
+        if (document.getElementsByClassName("comment").length > 0 || document.getElementsByClassName("comment have-children").length > 0)
+        onCommentsLoaded();
 	});
 }
 

--- a/contentScripts/imgurContent.js
+++ b/contentScripts/imgurContent.js
@@ -179,10 +179,8 @@ function imgurContentMain() {
 		});
                             
         // Since our mutationObserver tends to load too late to catch their inclusion, check to see if the comments have already been loaded.
-        // Note: This reduces but does not guarantee the elimination of the edge case where the comments load before the mutation observer.
-        // It's still possible for the comments to load after this line but before the mutation observer kicks in.
         if (document.getElementsByClassName("comment").length > 0 || document.getElementsByClassName("comment have-children").length > 0)
-        onCommentsLoaded();
+            onCommentsLoaded();
 	});
 }
 


### PR DESCRIPTION
Pulling in bugfix for via-mobile links not always being removed. The root cause of the issue appears to be that if the comments are loaded before the mutationObserver is invoked, the via-mobile links are not seen by the observer and are thus not removed. This issue appears to have been resolved by calling the onCommentsLoaded() function at page load, but since mutationObservers are asynchronous, I'm not 100% convinced that this edge case has been entirely closed. Further testing is warranted to verify whether or not the bug is actually fixed.
